### PR TITLE
Make build instructions work on Fedora 29

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ shc itself is not a compiler such as cc, it rather encodes and encrypts a shell 
 ## Install
 
 ```bash
+autoreconf -vfi
 ./configure
 make
 sudo make install


### PR DESCRIPTION
Without `autoreconf -vfi`, automake will look for versions that don't exist

```
[shc (release *% u=)]$ make
CDPATH="${ZSH_VERSION+.}:" && cd . && /bin/sh /opt/projects/shc/config/missing aclocal-1.15 -I m4
/opt/projects/shc/config/missing: line 81: aclocal-1.15: command not found
WARNING: 'aclocal-1.15' is missing on your system.
         You should only need it if you modified 'acinclude.m4' or
         'configure.ac' or m4 files included by 'configure.ac'.
         The 'aclocal' program is part of the GNU Automake package:
         <http://www.gnu.org/software/automake>
         It also requires GNU Autoconf, GNU m4 and Perl in order to run:
         <http://www.gnu.org/software/autoconf>
         <http://www.gnu.org/software/m4/>
         <http://www.perl.org/>
make: *** [Makefile:361: aclocal.m4] Error 127
```