### PR TITLE
fix typo in usage

### DIFF
--- a/src/shc.c
+++ b/src/shc.c
@@ -68,7 +68,7 @@ static const char * abstract[] = {
 0};
 
 static const char usage[] = 
-"Usage: shc [-e date] [-m addr] [-i iopt] [-x cmnd] [-l lopt] [-o outfile] [-rvDSUHCABh] -f script";
+"Usage: shc [-e date] [-m addr] [-i iopt] [-x cmd] [-l lopt] [-o outfile] [-rvDSUHCABh] -f script";
 
 static const char * help[] = {
 "",


### PR DESCRIPTION
There is a typo in the usage.




It's `cmnd`, but it's actually `cmd`.