### PR TITLE
remove the brackets that causing auto click URL in vt100  not working

### DIFF
--- a/man.md
+++ b/man.md
@@ -126,5 +126,5 @@ Francisco Rosales <frosal@fi.upm.es>
 Md Jahidul Hamid <jahidulhamid@yahoo.com>
 
 # REPORT BUGS TO
-<https://github.com/neurobin/shc/issues> 
+https://github.com/neurobin/shc/issues 
 

--- a/shc.1
+++ b/shc.1
@@ -144,4 +144,4 @@ intika <intika@librefox.org>
 Md Jahidul Hamid <jahidulhamid@yahoo.com>
 .SH REPORT BUGS TO
 .PP
-<https://github.com/neurobin/shc/issues>
+https://github.com/neurobin/shc/issues


### PR DESCRIPTION
Does the man page nroff format need <> to enclose an URL ? 

- The less/larger brackets are blocking the URL clicking from VT100.

![image](https://user-images.githubusercontent.com/378638/212548396-e15dae68-ee83-41ac-b520-4ff9b6ddef5f.png)

- 404 not found, after click on above URL in a chrome browser.

![image](https://user-images.githubusercontent.com/378638/212548549-93177f4f-763d-4dce-89eb-221b4abb9fad.png)

