### PR TITLE
Fix script file names containing spaces and other special characters.

### DIFF
--- a/src/shc.c
+++ b/src/shc.c
@@ -1318,7 +1318,7 @@ strcpy(file2,file);
 file2=strcat(file2,".x");
 
 }
-	sprintf(cmd, "%s %s %s %s.x.c -o %s", cc, cflags, ldflags, file, file2);
+	sprintf(cmd, "%s %s %s \'%s.x.c\' -o %s", cc, cflags, ldflags, file, file2);
 	if (verbose) fprintf(stderr, "%s: %s\n", my_name, cmd);
 	if (system(cmd))
 		return -1;


### PR DESCRIPTION
This pull request addresses the issue of script file names within the repository containing spaces and special characters. To enhance compatibility and maintainability, the following changes have been made:

Quoting variables prevents word splitting and glob expansion, and prevents the script from breaking when input contains spaces, line feeds, glob characters and such.

This update ensures that script files conform to best practices, making them more accessible and error-resistant.