### PR TITLE
Remove ash dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ sudo: required
 language: c
 before_install:
   - sudo apt-get update -q
-  - sudo apt install dash bash ash ksh zsh tcsh csh rc
+  - sudo apt install dash bash ksh zsh tcsh csh rc
 script: 
   - ./autogen.sh
   - ./configure

--- a/src/shc.c
+++ b/src/shc.c
@@ -1002,7 +1002,6 @@ struct {
 	{ "Rsh",  "-c", "",   "exec '%s' \"$@\"" }, /* AIX_nvi */
 	{ "ksh",  "-c", "",   "exec '%s' \"$@\"" }, /* OK on Solaris, AIX and Linux (THX <bryan.hogan@dstintl.com>) */
 	{ "tsh",  "-c", "--", "exec '%s' \"$@\"" }, /* AIX */
-	{ "ash",  "-c", "--", "exec '%s' \"$@\"" }, /* Linux */
 	{ "csh",  "-c", "-b", "exec '%s' $argv" }, /* AIX: No file for $0 */
 	{ "tcsh", "-c", "-b", "exec '%s' $argv" },
 	{ NULL,   NULL, NULL, NULL },

--- a/test/ttest.sh
+++ b/test/ttest.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-shells=('/bin/sh' '/bin/dash' '/bin/bash' '/bin/ash' '/bin/ksh' '/bin/zsh' '/usr/bin/tcsh' '/bin/csh' '/usr/bin/rc')
-## Install: sudo apt install dash bash ash ksh zsh tcsh csh rc
+shells=('/bin/sh' '/bin/dash' '/bin/bash' '/bin/ksh' '/bin/zsh' '/usr/bin/tcsh' '/bin/csh' '/usr/bin/rc')
+## Install: sudo apt install dash bash ksh zsh tcsh csh rc
 
 check_opts=('' '-r' '-v' '-D' '-S')
 


### PR DESCRIPTION
This PR drops the dependency on ash.

## Rationale:

The ash binary package was dropped in Debian unstable, see https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=920644 and will be removed for Ubuntu starting with Ubuntu 24.10 (Oracular Oriole), see https://bugs.launchpad.net/ubuntu/+source/dash/+bug/2073141.