### PR TITLE
Fix array overflow when outputting args to header

### DIFF
--- a/src/shc.c
+++ b/src/shc.c
@@ -797,13 +797,13 @@ static int parse_an_arg(int argc, char * argv[])
 		file = optarg;
 		break;
 	case 'i':
-		inlo = optarg;
+		inlo = strdup(optarg);  // Gets encrypted
 		break;
 	case 'x':
-		xecc = optarg;
+		xecc = strdup(optarg);  // Gets encrypted
 		break;
 	case 'l':
-		lsto = optarg;
+		lsto = strdup(optarg);  // Gets encrypted
 		break;
 	case 'o':
 		file2 = optarg;
@@ -1181,7 +1181,7 @@ void dump_array(FILE * o, void * ptr, char * name, int l, char * cast)
 	prnt_array(o, ptr, name, l, cast);
 }
 
-int write_C(char * file, int argc, char * argv[])
+int write_C(char *file, int argc, char *argv[])
 {
 	char pswd[256];
 	int pswd_z = sizeof(pswd);

--- a/src/shc.c
+++ b/src/shc.c
@@ -1181,7 +1181,7 @@ void dump_array(FILE * o, void * ptr, char * name, int l, char * cast)
 	prnt_array(o, ptr, name, l, cast);
 }
 
-int write_C(char * file, char * argv[])
+int write_C(char * file, int argc, char * argv[])
 {
 	char pswd[256];
 	int pswd_z = sizeof(pswd);
@@ -1253,7 +1253,7 @@ int write_C(char * file, char * argv[])
 	fprintf(o, "#if 0\n");
 	fprintf(o, "\t%s %s, %s\n", my_name, version, subject);
 	fprintf(o, "\t%s %s %s %s\n\n\t", cpright, provider.f, provider.s, provider.e);
-	for (indx = 0; argv[indx]; indx++)
+	for (indx = 0; indx < argc; indx++)
 		fprintf(o, "%s ", argv[indx]);
 	fprintf(o, "\n#endif\n\n");
 	fprintf(o, "static  char data [] = ");
@@ -1345,7 +1345,7 @@ void do_all(int argc, char * argv[])
 		return;
 	if (eval_shell(text))
 		return;
-	if (write_C(file, argv))
+	if (write_C(file, argc, argv))
 		return;
 	if (make())
 		return;


### PR DESCRIPTION
The loop over argv while outputting the arguments to the header was not bounded by argc.

The main issue was that the argements got encrypted.